### PR TITLE
chore: Update baseimage to jammy-1.0.2 and SOGo to jammy train

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 # Base image: https://hub.docker.com/r/phusion/baseimage/tags
-# FROM phusion/baseimage:jammy-1.0.1
-FROM phusion/baseimage:focal-1.2.0
+FROM phusion/baseimage:jammy-1.0.2
 
 # SOGo supported distributions: https://packages.sogo.nu/nightly/5/ubuntu/dists/
 RUN curl -L https://keys.openpgp.org/vks/v1/by-fingerprint/74FFC6D72B925A34B5D356BDF8A27B36A6E2EAE9 | gpg --dearmor > /usr/share/keyrings/sogo-archive-keyring.gpg
-# RUN echo "deb [signed-by=/usr/share/keyrings/sogo-archive-keyring.gpg] http://packages.inverse.ca/SOGo/nightly/5/ubuntu jammy jammy" > /etc/apt/sources.list.d/sogo.list
-RUN echo "deb [signed-by=/usr/share/keyrings/sogo-archive-keyring.gpg] http://packages.inverse.ca/SOGo/nightly/5/ubuntu focal focal" > /etc/apt/sources.list.d/sogo.list
+RUN echo "deb [signed-by=/usr/share/keyrings/sogo-archive-keyring.gpg] http://packages.inverse.ca/SOGo/nightly/5/ubuntu jammy jammy" > /etc/apt/sources.list.d/sogo.list
 
 # Install Apache, SOGo from repository
 RUN apt-get update && \
@@ -22,6 +20,7 @@ RUN usermod --home /srv/lib/sogo sogo
 # FIXME: somehow this confiugration causes a startup error
 # ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libssl.so
 ENV USEWATCHDOG=YES
+ENV LDAPTLS_CACERT=/etc/ssl/certs/ca-certificates.crt
 
 # SOGo daemons
 RUN mkdir -p /etc/service/sogod/log /etc/service/apache2/log /etc/service/memcached/log


### PR DESCRIPTION
 - Updates baseimge to Jammy 1.0.2
 - Switches SOGo to Jammy train
 - Provides CA Certs to LDAP for LDAPS capabilities (worked in focal without this change, no longer in jammy)